### PR TITLE
Upgrade default versions 

### DIFF
--- a/roles/centos7/elasticsearch_opendistro/defaults/main.yml
+++ b/roles/centos7/elasticsearch_opendistro/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for elasticsearch
 es_java_install: true
 update_java: false
-es_version: "7.1.1"
+es_version: "7.3.2"
 es_use_repository: true
 es_package_name: "elasticsearch-oss"
 es_restart_on_change: true
@@ -23,7 +23,7 @@ es_plugin_bin_path: /usr/share/elasticsearch/bin/elasticsearch-plugin
 es_sec_plugin_conf_path: /usr/share/elasticsearch/plugins/opendistro_security/securityconfig
 es_sec_plugin_tools_path: /usr/share/elasticsearch/plugins/opendistro_security/tools
 
-kibana_version: "7.1.1"
+kibana_version: "7.3.2"
 kibana_package_name: "kibana-oss"
 
 es_nodes_kibana: |-

--- a/roles/centos7/elasticsearch_opendistro/tasks/opendistro_security.yml
+++ b/roles/centos7/elasticsearch_opendistro/tasks/opendistro_security.yml
@@ -24,7 +24,7 @@
 - name: Security Plugin Install | Download certificates generation tool
   local_action:
     module: get_url
-    url: https://search.maven.org/remotecontent?filepath=com/floragunn/search-guard-tlstool/1.5/search-guard-tlstool-1.5.zip
+    url: https://search.maven.org/remotecontent?filepath=com/floragunn/search-guard-tlstool/1.7/search-guard-tlstool-1.7.zip
     dest: /tmp/opendistro-nodecerts/search-guard-tlstool.zip
   run_once: true
   when: install.changed


### PR DESCRIPTION
Upgrade the default versions of Kibana, Elasticsearch and search-guard-tlstool to have by default the latest versions available on opendistro.